### PR TITLE
Add dashboard pagination and fallback image

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -21,7 +21,9 @@ class CommentController extends Controller
             'content' => $request->content,
         ]);
 
-        return back();
+        return $request->wantsJson()
+            ? response()->json(['message' => 'created'])
+            : back();
     }
 
     public function update(Request $request, Comment $comment)
@@ -38,10 +40,12 @@ class CommentController extends Controller
             'content' => $request->input('content'),
         ]);
 
-        return back();
+        return $request->wantsJson()
+            ? response()->json(['message' => 'updated'])
+            : back();
     }
 
-    public function destroy(Comment $comment)
+    public function destroy(Request $request, Comment $comment)
     {
         if ($comment->user_id !== Auth::id()) {
             abort(403, 'No tienes permiso para eliminar este comentario.');
@@ -49,6 +53,8 @@ class CommentController extends Controller
 
         $comment->delete();
 
-        return back();
+        return $request->wantsJson()
+            ? response()->json(['message' => 'deleted'])
+            : back();
     }
 }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -9,9 +9,10 @@ class HomeController extends Controller
 {
     public function index(): \Inertia\Response
     {
-        $images = Image::with(['user', 'comments', 'likes']) // ⬅ Añadido eager loading
+        $images = Image::with(['user', 'comments', 'likes'])
             ->orderBy('created_at', 'desc')
-            ->paginate(5);
+            ->paginate(5)
+            ->withQueryString();
 
         return Inertia::render('Dashboard', [
             'images' => $images,

--- a/app/Http/Controllers/ImageController.php
+++ b/app/Http/Controllers/ImageController.php
@@ -5,22 +5,91 @@ namespace App\Http\Controllers;
 use App\Models\Image;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Redirect;
+use Illuminate\Support\Facades\Storage;
 
 
 class ImageController extends Controller
 {
+    public function create(): \Inertia\Response
+    {
+        return Inertia::render('Images/Create');
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'image' => ['required', 'image', 'max:4096'],
+            'description' => ['nullable', 'string', 'max:500'],
+        ]);
+
+        $path = $request->file('image')->store('images', 'public');
+
+        $image = Image::create([
+            'user_id' => Auth::id(),
+            'image_path' => $path,
+            'description' => $validated['description'] ?? null,
+        ]);
+
+        return Redirect::route('images.show', $image->id);
+    }
+
+    public function edit(Image $image): \Inertia\Response
+    {
+        if ($image->user_id !== Auth::id()) {
+            abort(403, 'No tienes permiso para editar esta imagen.');
+        }
+
+        return Inertia::render('Images/Edit', [
+            'image' => $image,
+        ]);
+    }
+
+    public function update(Request $request, Image $image)
+    {
+        if ($image->user_id !== Auth::id()) {
+            abort(403, 'No tienes permiso para editar esta imagen.');
+        }
+
+        $validated = $request->validate([
+            'image' => ['nullable', 'image', 'max:4096'],
+            'description' => ['nullable', 'string', 'max:500'],
+        ]);
+
+        if ($request->hasFile('image')) {
+            Storage::disk('public')->delete($image->image_path);
+            $image->image_path = $request->file('image')->store('images', 'public');
+        }
+
+        $image->description = $validated['description'] ?? $image->description;
+        $image->save();
+
+        return Redirect::route('images.show', $image->id);
+    }
+
+    public function destroy(Image $image)
+    {
+        if ($image->user_id !== Auth::id()) {
+            abort(403, 'No tienes permiso para eliminar esta imagen.');
+        }
+
+        Storage::disk('public')->delete($image->image_path);
+        $image->delete();
+
+        return Redirect::route('dashboard');
+    }
     /**
      * Display the specified image with its details.
      */
     public function show($id): \Inertia\Response
-{
-    $image = Image::with(['user', 'comments.user', 'likes'])->findOrFail($id);
+    {
+        $image = Image::with(['user', 'comments.user', 'likes'])->findOrFail($id);
 
-    return Inertia::render('Images/Show', [
-        'image' => $image,
-    ]);
-
-}
+        return Inertia::render('Images/Show', [
+            'image' => $image,
+        ]);
+    }
 
 
 

--- a/resources/js/Components/Pagination.jsx
+++ b/resources/js/Components/Pagination.jsx
@@ -1,0 +1,26 @@
+import { Link } from '@inertiajs/react';
+
+export default function Pagination({ links }) {
+    if (!links || links.length <= 3) return null;
+
+    return (
+        <div className="flex justify-center mt-6 gap-1">
+            {links.map((link, index) => (
+                link.url ? (
+                    <Link
+                        key={index}
+                        href={link.url}
+                        className={`px-3 py-1 text-sm rounded ${link.active ? 'bg-indigo-500 text-white' : 'text-gray-700 hover:bg-gray-200'}`}
+                        dangerouslySetInnerHTML={{ __html: link.label }}
+                    />
+                ) : (
+                    <span
+                        key={index}
+                        className="px-3 py-1 text-sm text-gray-400"
+                        dangerouslySetInnerHTML={{ __html: link.label }}
+                    />
+                )
+            ))}
+        </div>
+    );
+}

--- a/resources/js/Layouts/AuthenticatedLayout.jsx
+++ b/resources/js/Layouts/AuthenticatedLayout.jsx
@@ -34,6 +34,12 @@ export default function AuthenticatedLayout({ header, children }) {
                         </div>
 
                         <div className="hidden sm:ms-6 sm:flex sm:items-center">
+                            <Link
+                                href={route('images.create')}
+                                className="me-4 text-sm text-gray-600 hover:text-gray-800"
+                            >
+                                Nueva imagen
+                            </Link>
                             <div className="relative ms-3">
                                 <Dropdown>
                                     <Dropdown.Trigger>

--- a/resources/js/Pages/Dashboard.jsx
+++ b/resources/js/Pages/Dashboard.jsx
@@ -1,5 +1,6 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import { Head, usePage, Link } from '@inertiajs/react';
+import Pagination from '@/Components/Pagination';
 import { useEffect, useState } from 'react';
 import moment from 'moment';
 import 'moment/locale/es';
@@ -40,8 +41,9 @@ export default function Dashboard() {
                 {images.data.length === 0 ? (
                     <p className="text-gray-500">Encara no hi ha imatges.</p>
                 ) : (
-                    <div className="space-y-6">
-                        {images.data.map((image) => (
+                    <>
+                        <div className="space-y-6">
+                            {images.data.map((image) => (
                             <Link
                                 key={image.id}
                                 href={route('images.show', image.id)}
@@ -61,9 +63,11 @@ export default function Dashboard() {
                                     src={`/storage/${image.image_path}`}
                                     alt={image.description}
                                     className="rounded w-full mt-2"
-                                    onError={() =>
-                                        setError(`⚠️ No se pudo cargar la imagen: ${image.image_path}`)
-                                    }
+                                    onError={(e) => {
+                                        e.target.onerror = null;
+                                        e.target.src = 'https://via.placeholder.com/600x400?text=Imagen+no+disponible';
+                                        setError(`⚠️ No se pudo cargar la imagen: ${image.image_path}`);
+                                    }}
                                 />
 
                                 <p className="mt-2 text-gray-700">{image.description}</p>
@@ -73,8 +77,10 @@ export default function Dashboard() {
                                     <span>💬 {image.comments?.length || 0} comentarios</span>
                                 </div>
                             </Link>
-                        ))}
-                    </div>
+                            ))}
+                        </div>
+                        <Pagination links={images.links} />
+                    </>
                 )}
             </div>
         </AuthenticatedLayout>

--- a/resources/js/Pages/Images/Create.jsx
+++ b/resources/js/Pages/Images/Create.jsx
@@ -1,0 +1,43 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head, useForm, usePage } from '@inertiajs/react';
+
+export default function Create() {
+    const { auth } = usePage().props;
+    const { data, setData, post, processing, errors } = useForm({
+        image: null,
+        description: '',
+    });
+
+    const submit = (e) => {
+        e.preventDefault();
+        post(route('images.store'), {
+            forceFormData: true,
+        });
+    };
+
+    return (
+        <AuthenticatedLayout user={auth.user}>
+            <Head title="Nueva imagen" />
+            <div className="max-w-xl mx-auto py-8">
+                <form onSubmit={submit} className="space-y-4" encType="multipart/form-data">
+                    <div>
+                        <input type="file" onChange={(e) => setData('image', e.target.files[0])} required />
+                        {errors.image && <p className="text-red-600 text-sm mt-1">{errors.image}</p>}
+                    </div>
+                    <div>
+                        <textarea
+                            className="w-full border rounded p-2"
+                            value={data.description}
+                            onChange={(e) => setData('description', e.target.value)}
+                            placeholder="Descripci\u00f3n"
+                        />
+                        {errors.description && <p className="text-red-600 text-sm mt-1">{errors.description}</p>}
+                    </div>
+                    <button type="submit" disabled={processing} className="bg-blue-600 text-white px-4 py-1 rounded">
+                        Guardar
+                    </button>
+                </form>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/resources/js/Pages/Images/Edit.jsx
+++ b/resources/js/Pages/Images/Edit.jsx
@@ -1,0 +1,45 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head, useForm, usePage } from '@inertiajs/react';
+
+export default function Edit({ image }) {
+    const { auth } = usePage().props;
+    const { data, setData, post, processing, errors } = useForm({
+        image: null,
+        description: image.description ?? '',
+    });
+
+    const submit = (e) => {
+        e.preventDefault();
+        post(route('images.update', image.id), {
+            _method: 'put',
+            forceFormData: true,
+        });
+    };
+
+    return (
+        <AuthenticatedLayout user={auth.user}>
+            <Head title="Editar imagen" />
+            <div className="max-w-xl mx-auto py-8">
+                <form onSubmit={submit} className="space-y-4" encType="multipart/form-data">
+                    <div>
+                        <img src={`/storage/${image.image_path}`} alt="Imagen" className="mb-4 rounded" />
+                        <input type="file" onChange={(e) => setData('image', e.target.files[0])} />
+                        {errors.image && <p className="text-red-600 text-sm mt-1">{errors.image}</p>}
+                    </div>
+                    <div>
+                        <textarea
+                            className="w-full border rounded p-2"
+                            value={data.description}
+                            onChange={(e) => setData('description', e.target.value)}
+                            placeholder="Descripci\u00f3n"
+                        />
+                        {errors.description && <p className="text-red-600 text-sm mt-1">{errors.description}</p>}
+                    </div>
+                    <button type="submit" disabled={processing} className="bg-blue-600 text-white px-4 py-1 rounded">
+                        Actualizar
+                    </button>
+                </form>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/resources/js/Pages/Images/Show.jsx
+++ b/resources/js/Pages/Images/Show.jsx
@@ -1,5 +1,5 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
-import { Head, useForm, usePage } from '@inertiajs/react';
+import { Head, useForm, usePage, router } from '@inertiajs/react';
 import moment from 'moment';
 import 'moment/locale/es';
 import { useState } from 'react';
@@ -14,6 +14,8 @@ export default function Show({ image }) {
         content: '',
         image_id: image.id,
     });
+
+    const { delete: destroyImage } = useForm();
 
     const [editingCommentId, setEditingCommentId] = useState(null);
     const [editingContent, setEditingContent] = useState('');
@@ -60,6 +62,28 @@ export default function Show({ image }) {
 
                     <img src={`/storage/${image.image_path}`} alt={image.description} className="rounded w-full" />
                     <p className="mt-2 text-gray-800">{image.description}</p>
+                    {user.id === image.user_id && (
+                        <div className="mt-2 flex gap-4 text-sm">
+                            <a
+                                href={route('images.edit', image.id)}
+                                className="text-yellow-600"
+                            >
+                                ✏️ Editar
+                            </a>
+                            <button
+                                onClick={() => {
+                                    if (confirm('¿Seguro que quieres eliminar esta imagen?')) {
+                                        destroyImage(route('images.destroy', image.id), {
+                                            onSuccess: () => router.visit(route('dashboard')),
+                                        });
+                                    }
+                                }}
+                                className="text-red-600"
+                            >
+                                🗑 Eliminar
+                            </button>
+                        </div>
+                    )}
 
                     <div className="mt-4">
                         <h3 className="font-semibold mb-2">💬 Comentarios</h3>

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
@@ -9,7 +9,7 @@ import { Link, useForm, usePage } from '@inertiajs/react';
 export default function UpdateProfileInformationForm({ mustVerifyEmail, status, className = '' }) {
     const user = usePage().props.auth.user;
 
-    const { data, setData, patch, errors, processing, recentlySuccessful } = useForm({
+    const { data, setData, post, errors, processing, recentlySuccessful } = useForm({
         name: user.name ?? '',
         surname: user.surname ?? '',
         nick: user.nick ?? '',
@@ -20,9 +20,12 @@ export default function UpdateProfileInformationForm({ mustVerifyEmail, status, 
     const submit = (e) => {
         e.preventDefault();
 
-        patch(route('profile.update'), {
+        post(route('profile.update'), {
+            _method: 'patch',
             preserveScroll: true,
+            onSuccess: () => setData('avatar', null),
             onError: () => setData('avatar', null),
+            forceFormData: true,
         });
     };
 

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -2,3 +2,8 @@ import axios from 'axios';
 window.axios = axios;
 
 window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+
+const token = document.querySelector('meta[name="csrf-token"]');
+if (token) {
+    window.axios.defaults.headers.common['X-CSRF-TOKEN'] = token.getAttribute('content');
+}

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
 
         <title inertia>{{ config('app.name', 'Laravel') }}</title>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,7 +35,12 @@ Route::middleware('auth')->group(function () {
     Route::put('/comments/{comment}', [CommentController::class, 'update'])->name('comments.update');
     Route::delete('/comments/{comment}', [CommentController::class, 'destroy'])->name('comments.destroy');
 
-    // Vista individual de imagen
+    // Imágenes
+    Route::get('/images/create', [ImageController::class, 'create'])->name('images.create');
+    Route::post('/images', [ImageController::class, 'store'])->name('images.store');
+    Route::get('/images/{image}/edit', [ImageController::class, 'edit'])->name('images.edit');
+    Route::put('/images/{image}', [ImageController::class, 'update'])->name('images.update');
+    Route::delete('/images/{image}', [ImageController::class, 'destroy'])->name('images.destroy');
     Route::get('/images/{id}', [ImageController::class, 'show'])->name('images.show');
 });
 


### PR DESCRIPTION
## Summary
- include pagination links in dashboard
- keep query parameters when paginating
- show placeholder image if stored image can't be loaded
- allow owners to edit or delete images

## Testing
- `npm install`
- `npm run build`
- `composer install` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e084ca088321a733a77c1c426996