### PR TITLE
Allow image URLs and improve like interactions

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -21,7 +21,9 @@ class CommentController extends Controller
             'content' => $request->content,
         ]);
 
-        return back();
+        return $request->wantsJson()
+            ? response()->json(['message' => 'created'])
+            : back();
     }
 
     public function update(Request $request, Comment $comment)
@@ -38,10 +40,12 @@ class CommentController extends Controller
             'content' => $request->input('content'),
         ]);
 
-        return back();
+        return $request->wantsJson()
+            ? response()->json(['message' => 'updated'])
+            : back();
     }
 
-    public function destroy(Comment $comment)
+    public function destroy(Request $request, Comment $comment)
     {
         if ($comment->user_id !== Auth::id()) {
             abort(403, 'No tienes permiso para eliminar este comentario.');
@@ -49,6 +53,8 @@ class CommentController extends Controller
 
         $comment->delete();
 
-        return back();
+        return $request->wantsJson()
+            ? response()->json(['message' => 'deleted'])
+            : back();
     }
 }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -9,9 +9,10 @@ class HomeController extends Controller
 {
     public function index(): \Inertia\Response
     {
-        $images = Image::with(['user', 'comments', 'likes']) // ⬅ Añadido eager loading
+        $images = Image::with(['user', 'comments', 'likes'])
             ->orderBy('created_at', 'desc')
-            ->paginate(5);
+            ->paginate(5)
+            ->withQueryString();
 
         return Inertia::render('Dashboard', [
             'images' => $images,

--- a/app/Http/Controllers/ImageController.php
+++ b/app/Http/Controllers/ImageController.php
@@ -5,22 +5,111 @@ namespace App\Http\Controllers;
 use App\Models\Image;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Redirect;
+use Illuminate\Support\Facades\Storage;
 
 
 class ImageController extends Controller
 {
+    public function create(): \Inertia\Response
+    {
+        return Inertia::render('Images/Create');
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'image' => ['nullable', 'image', 'max:4096'],
+            'image_url' => ['nullable', 'url'],
+            'description' => ['nullable', 'string', 'max:500'],
+        ]);
+
+        if (!$request->hasFile('image') && empty($validated['image_url'])) {
+            return Redirect::back()->withErrors(['image' => 'Debe subir una imagen o indicar una URL.']);
+        }
+
+        if ($request->hasFile('image')) {
+            $path = $request->file('image')->store('images', 'public');
+        } else {
+            $contents = @file_get_contents($validated['image_url']);
+            $ext = pathinfo(parse_url($validated['image_url'], PHP_URL_PATH), PATHINFO_EXTENSION) ?: 'jpg';
+            $path = 'images/' . uniqid() . '.' . $ext;
+            Storage::disk('public')->put($path, $contents);
+        }
+
+        $image = Image::create([
+            'user_id' => Auth::id(),
+            'image_path' => $path,
+            'description' => $validated['description'] ?? null,
+        ]);
+
+        return Redirect::route('images.show', $image->id);
+    }
+
+    public function edit(Image $image): \Inertia\Response
+    {
+        if ($image->user_id !== Auth::id()) {
+            abort(403, 'No tienes permiso para editar esta imagen.');
+        }
+
+        return Inertia::render('Images/Edit', [
+            'image' => $image,
+        ]);
+    }
+
+    public function update(Request $request, Image $image)
+    {
+        if ($image->user_id !== Auth::id()) {
+            abort(403, 'No tienes permiso para editar esta imagen.');
+        }
+
+        $validated = $request->validate([
+            'image' => ['nullable', 'image', 'max:4096'],
+            'image_url' => ['nullable', 'url'],
+            'description' => ['nullable', 'string', 'max:500'],
+        ]);
+
+        if ($request->hasFile('image')) {
+            Storage::disk('public')->delete($image->image_path);
+            $image->image_path = $request->file('image')->store('images', 'public');
+        } elseif (!empty($validated['image_url'])) {
+            Storage::disk('public')->delete($image->image_path);
+            $contents = @file_get_contents($validated['image_url']);
+            $ext = pathinfo(parse_url($validated['image_url'], PHP_URL_PATH), PATHINFO_EXTENSION) ?: 'jpg';
+            $path = 'images/' . uniqid() . '.' . $ext;
+            Storage::disk('public')->put($path, $contents);
+            $image->image_path = $path;
+        }
+
+        $image->description = $validated['description'] ?? $image->description;
+        $image->save();
+
+        return Redirect::route('images.show', $image->id);
+    }
+
+    public function destroy(Image $image)
+    {
+        if ($image->user_id !== Auth::id()) {
+            abort(403, 'No tienes permiso para eliminar esta imagen.');
+        }
+
+        Storage::disk('public')->delete($image->image_path);
+        $image->delete();
+
+        return Redirect::route('dashboard');
+    }
     /**
      * Display the specified image with its details.
      */
     public function show($id): \Inertia\Response
-{
-    $image = Image::with(['user', 'comments.user', 'likes'])->findOrFail($id);
+    {
+        $image = Image::with(['user', 'comments.user', 'likes'])->findOrFail($id);
 
-    return Inertia::render('Images/Show', [
-        'image' => $image,
-    ]);
-
-}
+        return Inertia::render('Images/Show', [
+            'image' => $image,
+        ]);
+    }
 
 
 

--- a/app/Http/Controllers/LikeController.php
+++ b/app/Http/Controllers/LikeController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Image;
+use App\Models\Like;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Redirect;
+
+class LikeController extends Controller
+{
+    public function store(Request $request, Image $image)
+    {
+        $like = Like::firstOrCreate([
+            'image_id' => $image->id,
+            'user_id' => Auth::id(),
+        ]);
+
+        if ($request->wantsJson()) {
+            $image->loadCount('likes');
+            return response()->json([
+                'liked' => true,
+                'count' => $image->likes_count,
+            ]);
+        }
+
+        return Redirect::back();
+    }
+
+    public function destroy(Request $request, Image $image)
+    {
+        Like::where('image_id', $image->id)
+            ->where('user_id', Auth::id())
+            ->delete();
+
+        if ($request->wantsJson()) {
+            $image->loadCount('likes');
+            return response()->json([
+                'liked' => false,
+                'count' => $image->likes_count,
+            ]);
+        }
+
+        return Redirect::back();
+    }
+}

--- a/resources/js/Components/LikeButton.jsx
+++ b/resources/js/Components/LikeButton.jsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+
+export default function LikeButton({ imageId, initialLiked, initialCount }) {
+    const [liked, setLiked] = useState(initialLiked);
+    const [count, setCount] = useState(initialCount);
+
+    const toggle = (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const request = liked
+            ? window.axios.delete(route('images.unlike', imageId))
+            : window.axios.post(route('images.like', imageId));
+
+        request.then((res) => {
+            if (res.data && typeof res.data.count !== 'undefined') {
+                setCount(res.data.count);
+            } else {
+                setCount((c) => (liked ? c - 1 : c + 1));
+            }
+            setLiked(!liked);
+        });
+    };
+
+    return (
+        <button
+            onClick={toggle}
+            className="flex items-center gap-1 focus:outline-none"
+        >
+            <span className={liked ? 'text-red-600' : 'text-gray-600'}>
+                {liked ? '❤️' : '♡'}
+            </span>
+            <span className="text-sm text-gray-600">{count}</span>
+        </button>
+    );
+}

--- a/resources/js/Components/Pagination.jsx
+++ b/resources/js/Components/Pagination.jsx
@@ -1,0 +1,26 @@
+import { Link } from '@inertiajs/react';
+
+export default function Pagination({ links }) {
+    if (!links || links.length <= 3) return null;
+
+    return (
+        <div className="flex justify-center mt-6 gap-1">
+            {links.map((link, index) => (
+                link.url ? (
+                    <Link
+                        key={index}
+                        href={link.url}
+                        className={`px-3 py-1 text-sm rounded ${link.active ? 'bg-indigo-500 text-white' : 'text-gray-700 hover:bg-gray-200'}`}
+                        dangerouslySetInnerHTML={{ __html: link.label }}
+                    />
+                ) : (
+                    <span
+                        key={index}
+                        className="px-3 py-1 text-sm text-gray-400"
+                        dangerouslySetInnerHTML={{ __html: link.label }}
+                    />
+                )
+            ))}
+        </div>
+    );
+}

--- a/resources/js/Layouts/AuthenticatedLayout.jsx
+++ b/resources/js/Layouts/AuthenticatedLayout.jsx
@@ -34,6 +34,12 @@ export default function AuthenticatedLayout({ header, children }) {
                         </div>
 
                         <div className="hidden sm:ms-6 sm:flex sm:items-center">
+                            <Link
+                                href={route('images.create')}
+                                className="me-4 text-sm text-gray-600 hover:text-gray-800"
+                            >
+                                Nueva imagen
+                            </Link>
                             <div className="relative ms-3">
                                 <Dropdown>
                                     <Dropdown.Trigger>
@@ -143,6 +149,9 @@ export default function AuthenticatedLayout({ header, children }) {
                             active={route().current('dashboard')}
                         >
                             Dashboard
+                        </ResponsiveNavLink>
+                        <ResponsiveNavLink href={route('images.create')}>
+                            Nueva imagen
                         </ResponsiveNavLink>
                     </div>
 

--- a/resources/js/Pages/Dashboard.jsx
+++ b/resources/js/Pages/Dashboard.jsx
@@ -1,5 +1,7 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import { Head, usePage, Link } from '@inertiajs/react';
+import Pagination from '@/Components/Pagination';
+import LikeButton from '@/Components/LikeButton';
 import { useEffect, useState } from 'react';
 import moment from 'moment';
 import 'moment/locale/es';
@@ -40,8 +42,9 @@ export default function Dashboard() {
                 {images.data.length === 0 ? (
                     <p className="text-gray-500">Encara no hi ha imatges.</p>
                 ) : (
-                    <div className="space-y-6">
-                        {images.data.map((image) => (
+                    <>
+                        <div className="space-y-6">
+                            {images.data.map((image) => (
                             <Link
                                 key={image.id}
                                 href={route('images.show', image.id)}
@@ -61,20 +64,28 @@ export default function Dashboard() {
                                     src={`/storage/${image.image_path}`}
                                     alt={image.description}
                                     className="rounded w-full mt-2"
-                                    onError={() =>
-                                        setError(`⚠️ No se pudo cargar la imagen: ${image.image_path}`)
-                                    }
+                                    onError={(e) => {
+                                        e.target.onerror = null;
+                                        e.target.src = 'https://via.placeholder.com/600x400?text=Imagen+no+disponible';
+                                        setError(`⚠️ No se pudo cargar la imagen: ${image.image_path}`);
+                                    }}
                                 />
 
                                 <p className="mt-2 text-gray-700">{image.description}</p>
 
                                 <div className="flex items-center mt-4 text-sm text-gray-600 gap-4">
-                                    <span>❤️ {image.likes?.length || 0} likes</span>
+                                    <LikeButton
+                                        imageId={image.id}
+                                        initialLiked={image.likes?.some(l => l.user_id === user.id)}
+                                        initialCount={image.likes?.length || 0}
+                                    />
                                     <span>💬 {image.comments?.length || 0} comentarios</span>
                                 </div>
                             </Link>
-                        ))}
-                    </div>
+                            ))}
+                        </div>
+                        <Pagination links={images.links} />
+                    </>
                 )}
             </div>
         </AuthenticatedLayout>

--- a/resources/js/Pages/Images/Create.jsx
+++ b/resources/js/Pages/Images/Create.jsx
@@ -1,0 +1,69 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head, useForm, usePage } from '@inertiajs/react';
+
+export default function Create() {
+    const { auth } = usePage().props;
+    const { data, setData, post, processing, errors } = useForm({
+        image: null,
+        image_url: '',
+        description: '',
+    });
+
+    const submit = (e) => {
+        e.preventDefault();
+        post(route('images.store'), {
+            forceFormData: true,
+        });
+    };
+
+    return (
+        <AuthenticatedLayout user={auth.user}>
+            <Head title="Nueva imagen" />
+            <div className="max-w-xl mx-auto py-8">
+                <form onSubmit={submit} className="space-y-4" encType="multipart/form-data">
+                    <div>
+                        <input type="file" onChange={(e) => setData('image', e.target.files[0])} />
+                        {errors.image && <p className="text-red-600 text-sm mt-1">{errors.image}</p>}
+                    </div>
+                    <div>
+                        <input
+                            type="text"
+                            placeholder="URL de la imagen"
+                            className="w-full border rounded p-2"
+                            value={data.image_url}
+                            onChange={(e) => setData('image_url', e.target.value)}
+                        />
+                        {errors.image_url && (
+                            <p className="text-red-600 text-sm mt-1">{errors.image_url}</p>
+                        )}
+                    </div>
+                    <div>
+                        <textarea
+                            className="w-full border rounded p-2"
+                            value={data.description}
+                            onChange={(e) => setData('description', e.target.value)}
+                            placeholder="Descripci\u00f3n"
+                        />
+                        {errors.description && (
+                            <p className="text-red-600 text-sm mt-1">{errors.description}</p>
+                        )}
+                    </div>
+                    <div>
+                        <button
+                            type="button"
+                            onClick={() =>
+                                setData('image_url', `https://source.unsplash.com/random/800x600?sig=${Date.now()}`)
+                            }
+                            className="text-sm text-blue-600 underline"
+                        >
+                            Usar imagen aleatoria
+                        </button>
+                    </div>
+                    <button type="submit" disabled={processing} className="bg-blue-600 text-white px-4 py-1 rounded">
+                        Guardar
+                    </button>
+                </form>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/resources/js/Pages/Images/Edit.jsx
+++ b/resources/js/Pages/Images/Edit.jsx
@@ -1,0 +1,71 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head, useForm, usePage } from '@inertiajs/react';
+
+export default function Edit({ image }) {
+    const { auth } = usePage().props;
+    const { data, setData, post, processing, errors } = useForm({
+        image: null,
+        image_url: '',
+        description: image.description ?? '',
+    });
+
+    const submit = (e) => {
+        e.preventDefault();
+        post(route('images.update', image.id), {
+            _method: 'put',
+            forceFormData: true,
+        });
+    };
+
+    return (
+        <AuthenticatedLayout user={auth.user}>
+            <Head title="Editar imagen" />
+            <div className="max-w-xl mx-auto py-8">
+                <form onSubmit={submit} className="space-y-4" encType="multipart/form-data">
+                    <div>
+                        <img src={`/storage/${image.image_path}`} alt="Imagen" className="mb-4 rounded" />
+                        <input type="file" onChange={(e) => setData('image', e.target.files[0])} />
+                        {errors.image && <p className="text-red-600 text-sm mt-1">{errors.image}</p>}
+                    </div>
+                    <div>
+                        <input
+                            type="text"
+                            placeholder="URL de la imagen"
+                            className="w-full border rounded p-2"
+                            value={data.image_url}
+                            onChange={(e) => setData('image_url', e.target.value)}
+                        />
+                        {errors.image_url && (
+                            <p className="text-red-600 text-sm mt-1">{errors.image_url}</p>
+                        )}
+                    </div>
+                    <div>
+                        <textarea
+                            className="w-full border rounded p-2"
+                            value={data.description}
+                            onChange={(e) => setData('description', e.target.value)}
+                            placeholder="Descripci\u00f3n"
+                        />
+                        {errors.description && (
+                            <p className="text-red-600 text-sm mt-1">{errors.description}</p>
+                        )}
+                    </div>
+                    <div>
+                        <button
+                            type="button"
+                            onClick={() =>
+                                setData('image_url', `https://source.unsplash.com/random/800x600?sig=${Date.now()}`)
+                            }
+                            className="text-sm text-blue-600 underline"
+                        >
+                            Usar imagen aleatoria
+                        </button>
+                    </div>
+                    <button type="submit" disabled={processing} className="bg-blue-600 text-white px-4 py-1 rounded">
+                        Actualizar
+                    </button>
+                </form>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/resources/js/Pages/Images/Show.jsx
+++ b/resources/js/Pages/Images/Show.jsx
@@ -120,11 +120,24 @@ export default function Show({ image }) {
                                         <p className="text-gray-700">{comment.content}</p>
                                         {comment.user.id === user.id && (
                                             <div className="flex gap-2 text-xs">
-                                                <button onClick={() => {
-                                                    setEditingCommentId(comment.id);
-                                                    setEditingContent(comment.content);
-                                                }} className="text-yellow-600">✏️ Editar</button>
-                                                <button onClick={(e) => handleDelete(comment.id, e)} className="text-red-600">🗑 Eliminar</button>
+                                                <button
+                                                    type="button"
+                                                    onClick={(e) => {
+                                                        e.stopPropagation();
+                                                        setEditingCommentId(comment.id);
+                                                        setEditingContent(comment.content);
+                                                    }}
+                                                    className="text-yellow-600"
+                                                >
+                                                    ✏️ Editar
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    onClick={(e) => handleDelete(comment.id, e)}
+                                                    className="text-red-600"
+                                                >
+                                                    🗑 Eliminar
+                                                </button>
                                             </div>
                                         )}
                                     </div>

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
@@ -9,7 +9,7 @@ import { Link, useForm, usePage } from '@inertiajs/react';
 export default function UpdateProfileInformationForm({ mustVerifyEmail, status, className = '' }) {
     const user = usePage().props.auth.user;
 
-    const { data, setData, patch, errors, processing, recentlySuccessful } = useForm({
+    const { data, setData, post, errors, processing, recentlySuccessful } = useForm({
         name: user.name ?? '',
         surname: user.surname ?? '',
         nick: user.nick ?? '',
@@ -20,9 +20,12 @@ export default function UpdateProfileInformationForm({ mustVerifyEmail, status, 
     const submit = (e) => {
         e.preventDefault();
 
-        patch(route('profile.update'), {
+        post(route('profile.update'), {
+            _method: 'patch',
             preserveScroll: true,
+            onSuccess: () => setData('avatar', null),
             onError: () => setData('avatar', null),
+            forceFormData: true,
         });
     };
 

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
@@ -9,7 +9,7 @@ import { Link, useForm, usePage } from '@inertiajs/react';
 export default function UpdateProfileInformationForm({ mustVerifyEmail, status, className = '' }) {
     const user = usePage().props.auth.user;
 
-    const { data, setData, post, errors, processing, recentlySuccessful } = useForm({
+    const { data, setData, patch, errors, processing, recentlySuccessful } = useForm({
         name: user.name ?? '',
         surname: user.surname ?? '',
         nick: user.nick ?? '',
@@ -20,8 +20,7 @@ export default function UpdateProfileInformationForm({ mustVerifyEmail, status, 
     const submit = (e) => {
         e.preventDefault();
 
-        post(route('profile.update'), {
-            _method: 'patch',
+        patch(route('profile.update'), {
             preserveScroll: true,
             onSuccess: () => setData('avatar', null),
             onError: () => setData('avatar', null),

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -2,3 +2,8 @@ import axios from 'axios';
 window.axios = axios;
 
 window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+
+const token = document.querySelector('meta[name="csrf-token"]');
+if (token) {
+    window.axios.defaults.headers.common['X-CSRF-TOKEN'] = token.getAttribute('content');
+}

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
 
         <title inertia>{{ config('app.name', 'Laravel') }}</title>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,8 +35,17 @@ Route::middleware('auth')->group(function () {
     Route::put('/comments/{comment}', [CommentController::class, 'update'])->name('comments.update');
     Route::delete('/comments/{comment}', [CommentController::class, 'destroy'])->name('comments.destroy');
 
-    // Vista individual de imagen
+    // Imágenes
+    Route::get('/images/create', [ImageController::class, 'create'])->name('images.create');
+    Route::post('/images', [ImageController::class, 'store'])->name('images.store');
+    Route::get('/images/{image}/edit', [ImageController::class, 'edit'])->name('images.edit');
+    Route::put('/images/{image}', [ImageController::class, 'update'])->name('images.update');
+    Route::delete('/images/{image}', [ImageController::class, 'destroy'])->name('images.destroy');
     Route::get('/images/{id}', [ImageController::class, 'show'])->name('images.show');
+
+    // Likes
+    Route::post('/images/{image}/likes', [\App\Http\Controllers\LikeController::class, 'store'])->name('images.like');
+    Route::delete('/images/{image}/likes', [\App\Http\Controllers\LikeController::class, 'destroy'])->name('images.unlike');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- support uploading images via URL in `ImageController`
- prevent navigation when clicking heart icons
- handle random/remote image URLs in create and edit forms
- stop event bubbling for comment edit/delete actions

## Testing
- `npm install`
- `npm run build` *(failed: util-deprecate module missing)*
- `composer install` *(command not found)*
- `php artisan test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e084ca088321a733a77c1c426996