### PR TITLE
Fix profile update method error

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -27,7 +27,7 @@ Route::middleware('auth')->group(function () {
 
     // Perfil
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
-    Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
+    Route::match(['patch', 'post'], '/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 
     // Comentarios


### PR DESCRIPTION
## Summary
- allow POST requests for `/profile` updates so `_method: patch` forms work

## Testing
- `composer install`
- `php artisan test` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_68482b4f4308832182b3df5bf593994d